### PR TITLE
Enable default stage in deployVariables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,8 @@ class ServerlessDeployEnvironment {
     // TODO(msills): Figure out how to avoid this. For now, it seems safe.
     serverless.variables.loadVariableSyntax()
     // Explicitly resolve these here, so that we can apply any transformations that we want
-    serverless.service.deployVariables = deasyncPromise(serverless.variables.populateProperty(deployVariables, false))[stage] || { } // eslint-disable-line
+    const vars = deasyncPromise(serverless.variables.populateProperty(deployVariables, false))
+    serverless.service.deployVariables = _.merge(vars.default || {  }, vars[stage]) // eslint-disable-line
     const envs = deasyncPromise(serverless.variables.populateProperty(deployEnvironment, false)) // eslint-disable-line
     serverless.service.deployEnvironment = _.merge(envs.default || { }, envs[stage]) // eslint-disable-line
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -85,6 +85,34 @@ test('deployVariables are populated by stage', t => {
   t.deepEqual(sls.service.deployVariables, { })
 })
 
+test('deployVariables merges defaults', t => {
+  const sls = new Serverless()
+
+  const expectedDeployVariables = {
+    a: 1,
+    b: { a: 2  },
+    c: ['a', 'b', 'c']
+  }
+
+  sls.service.custom = {
+    defaults: {
+      stage: 'test'
+    },
+    deploy: {
+      variables: {
+        default: { a: 1 },
+        test: {
+          b: { a: 2 },
+          c: ['a', 'b', 'c']
+        }
+      }
+    }
+  }
+
+  initServerlessPlugin(sls)
+  t.deepEqual(sls.service.deployVariables, expectedDeployVariables)
+})
+
 test('deployEnvironments merges defaults', t => {
   const sls = new Serverless()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -90,7 +90,7 @@ test('deployVariables merges defaults', t => {
 
   const expectedDeployVariables = {
     a: 1,
-    b: { a: 2  },
+    b: { a: 2 },
     c: ['a', 'b', 'c']
   }
 


### PR DESCRIPTION
Change deployVariables to accept variables defined in a default stage.
Change deployVariables to populate any default stage variables to each other stage.
Write test for this functionality.